### PR TITLE
Install python systemd dependencies; Read second LDAP attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ This role requires an apt based system.
 | `ldap_use_ssl`                     | `true`             | To enable or disable SSL on LDAP connections               |
 | `ldap_server`                      | :heavy_check_mark: | URL to for the LDAP server that should be queried          |
 | `ldap_base_dn`                     | :heavy_check_mark: | Base DN for LDAP search                                    |
-| `ldap_user`                        | :heavy_check_mark: | DN of user used for bind
-| `ldap_user_secret`                 | :heavy_check_mark: | Password of the user for bind
+| `ldap_user`                        | :heavy_check_mark: | DN of user used for bind                                   |
+| `ldap_user_secret`                 | :heavy_check_mark: | Password of the user for bind                              |
 | `ldap_match_attr`                  | :heavy_check_mark: | Attribute that should be looked up                         |
+| `ldap_owner_attr`                  | :heavy_check_mark: | Attribute that contains the card owner (used for looging)  |
 
 ## Example Playbook
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,14 +11,17 @@
     depth: 1
     force: yes
 
-- name: Install python deps apt and pcscd
+- name: Install dependencies
   apt:
     name:
       - pcscd
+      - build-essential
+      - libsystemd-dev
       - python3-pyscard
       - python3-ldap3
       - python3-yaml
       - python3-pip
+      - python3-systemd
 
 - name: Install python3-pifacecommon and pifacedigitalio
   pip:

--- a/templates/door.service.j2
+++ b/templates/door.service.j2
@@ -7,7 +7,7 @@ WorkingDirectory={{ rfid_tuer_ansible_install_path }}
 Restart=always
 RestartSec=3
 User={{ rfid_tuer_ansible_user }}
-Group = {{ rfid_tuer_ansible_group }}
+Group={{ rfid_tuer_ansible_group }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The dependencies are necessary for systemd logging in python.
The second LDAP attribute is used to identify and log the owner.